### PR TITLE
Print options using "dmarc_view_reports --help"

### DIFF
--- a/bin/dmarc_view_reports
+++ b/bin/dmarc_view_reports
@@ -164,8 +164,6 @@ __END__
 
   dmarc_view_reports [ --option=value ]
 
-=head1 DESCRIPTION
-
 Dumps the contents of the DMARC data store to your terminal. The most recent records are show first.
 
 =head2 Search Options


### PR DESCRIPTION
Because pod2usage prints only the SYNOPSIS section by default, the "--help" argument to dmarc_view_reports does not output any of the available option names.

This PR merges the DESCRIPTION section into SYNOPSIS, so "--help" prints the full syntax guide. This matches the documentation's description of the help option.